### PR TITLE
Replace use of r2d2 with redis-rs ConnectionManager

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ edition = "2018"
 travis-ci = { repository = "spk/rust-sidekiq" }
 
 [dependencies]
+futures = "*"
 rand = "0.8"
 serde = "1.0"
 serde_json = "1.0"
-r2d2 = "0.8"
-r2d2_redis = "0.14"
+redis = { version = "*", features = ["connection-manager", "async-std-comp", "async-std-tls-comp"] }
 time = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ extern crate serde_json;
 
 mod sidekiq;
 pub use crate::sidekiq::{
-    create_redis_pool, Client, ClientError, ClientOpts, Job, JobOpts, RedisPool,
+    create_async_redis_pool, create_redis_pool, Client, ClientError, ClientOpts, Job, JobOpts,
+    RedisPool,
 };
 pub use serde_json::value::Value;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,6 @@
 #![deny(warnings)]
 #![crate_name = "sidekiq"]
 
-extern crate r2d2;
-extern crate r2d2_redis;
 extern crate rand;
 extern crate serde;
 extern crate serde_json;
@@ -19,6 +17,5 @@ extern crate serde_json;
 mod sidekiq;
 pub use crate::sidekiq::{
     create_redis_pool, Client, ClientError, ClientOpts, Job, JobOpts, RedisPool,
-    RedisPooledConnection,
 };
 pub use serde_json::value::Value;


### PR DESCRIPTION
Using r2d2 with redis isn't really necessary, as the redis crate can
multiplex a connection, and in fact its the recommended approach for most
use cases: https://github.com/redis-rs/redis-rs/pull/388#issuecomment-911589177

Therefore this changes things to use redis-rs internally, with the intent
of adding an async API to this crate in the future. Additionally this
enables TLS for Redis connections, to support Redis servers that require
TLS.

This change is mostly API-compatible, but does change the underlying
RedisPool type (its still called "pool", but its actually a
ConnectionManager), and drops the exported type RedisPooledConnection.